### PR TITLE
Page-specific calendar JS load

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,99 +1,11 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require_tree .
+//= require_tree ./sitewide
 //= require main
 //= require locales-all
 //= require moment 
+//= require ./tasks/calendar
+//= require ./tasks/list
 
 "use strict";
-
-document.addEventListener('DOMContentLoaded', function () {
-  var calendarEl = document.getElementById('calendar');
-  // TODO: Don't make this global :)
-  calendar = new FullCalendar.Calendar(calendarEl, {
-    selectable: true,
-    headerToolbar: {
-      left: 'prev,next today',
-      center: 'title',
-      right: 'dayGridMonth,timeGridWeek,timeGridDay'
-    },
-    eventSources: [{
-      url: '/tasks/calendar_tasks',
-      method: 'GET',
-      failure: function () {
-        alert('there was an error while fetching tasks!');
-      }
-    }],
-    select: function (info) {
-      var title = prompt('Enter Title');
-      if (title) {
-        jQuery.post(
-            "/tasks", {
-              task: {
-                title: title,
-                start: info.start,
-                due: info.end,
-                calendar: true
-              }
-            }).done(function () {
-            calendar.refetchEvents();
-            reRenderList();
-          })
-          .fail(function () {
-            alert("ERROR: Task could not be created!");
-          })
-          .always(function () {
-            calendar.unselect();
-          });
-      }
-    },
-    editable: true,
-    droppable: true,
-    eventDrop: function (info) {
-      if (info.event.id != undefined) {
-        $.ajax({
-          url: '/tasks/' + info.event.id,
-          type: 'PATCH',
-          data: {
-            task: {
-              title: info.event.title,
-              description: info.event._def.extendedProps.description,
-              start: info.event.start,
-              due: info.event.end,
-              calendar: true,
-              update: true
-            }
-          },
-          success: function () {
-            calendar.refetchEvents();
-            reRenderList();
-          },
-          error: function () {
-            alert("ERROR: Task information could not be updated!");
-          }
-        });
-      }
-    },
-    initialView: 'dayGridMonth',
-    expandRows: true,
-    height: "100%",
-    dayCellClassNames: 'dark-section'
-  });
-  calendar.render();
-
-  handleAlerts();
-});
-
-function reRenderList() {
-  $.get("/tasks/update_partials")
-}
-
-// Alerts 
-
-function handleAlerts() {
-  // delete alert on exit click
-  $(".alert-pop-up img").on("click", function () {
-    $(this).parent().remove()
-  })
-}

--- a/app/assets/javascripts/sitewide/alerts.js
+++ b/app/assets/javascripts/sitewide/alerts.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function () {
+    handleAlerts();
+});
+
+// Alerts 
+
+function handleAlerts() {
+    // delete alert on exit click
+    $(".alert-pop-up img").on("click", function () {
+        $(this).parent().remove()
+    })
+}

--- a/app/assets/javascripts/tasks/calendar.js
+++ b/app/assets/javascripts/tasks/calendar.js
@@ -1,0 +1,82 @@
+document.addEventListener('DOMContentLoaded', function () {
+    // Only run if body has tasks class
+    if ($('body.tasks').length) {
+
+        var calendarEl = document.getElementById('calendar');
+        calendar = new FullCalendar.Calendar(calendarEl, {
+            selectable: true,
+            headerToolbar: {
+                left: 'prev,next today',
+                center: 'title',
+                right: 'dayGridMonth,timeGridWeek,timeGridDay'
+            },
+            eventSources: [{
+                url: '/tasks/calendar_tasks',
+                method: 'GET',
+                failure: function () {
+                    alert('there was an error while fetching tasks!');
+                }
+            }],
+            select: function (info) {
+                var title = prompt('Enter Title');
+                if (title) {
+                    jQuery.post(
+                            "/tasks", {
+                                task: {
+                                    title: title,
+                                    start: info.start,
+                                    due: info.end,
+                                    calendar: true
+                                }
+                            }).done(function () {
+                            calendar.refetchEvents();
+                            reRenderList();
+                        })
+                        .fail(function () {
+                            alert("ERROR: Task could not be created!");
+                        })
+                        .always(function () {
+                            calendar.unselect();
+                        });
+                }
+            },
+            editable: true,
+            droppable: true,
+            eventDrop: function (info) {
+                if (info.event.id != undefined) {
+                    $.ajax({
+                        url: '/tasks/' + info.event.id,
+                        type: 'PATCH',
+                        data: {
+                            task: {
+                                title: info.event.title,
+                                description: info.event._def.extendedProps.description,
+                                start: info.event.start,
+                                due: info.event.end,
+                                calendar: true,
+                                update: true
+                            }
+                        },
+                        success: function () {
+                            calendar.refetchEvents();
+                            reRenderList();
+                        },
+                        error: function () {
+                            alert("ERROR: Task information could not be updated!");
+                        }
+                    });
+                }
+            },
+            initialView: 'dayGridMonth',
+            expandRows: true,
+            height: "100%",
+            dayCellClassNames: 'dark-section'
+        });
+        calendar.render();
+    }
+});
+
+
+function reRenderList() {
+    $.get("/tasks/update_partials")
+}

--- a/app/assets/javascripts/tasks/list.js
+++ b/app/assets/javascripts/tasks/list.js
@@ -1,4 +1,3 @@
-"use strict";
 
 document.addEventListener('DOMContentLoaded', function () {
 

--- a/app/assets/stylesheets/calendar.scss
+++ b/app/assets/stylesheets/calendar.scss
@@ -97,3 +97,11 @@
 .fc .fc-daygrid-day.fc-day-today {
   background-color: var(--fc-today-bg-color, rgba(255, 255, 255, 0.11));
 }
+
+.fc .fc-button-group button.fc-button.fc-button-primary {
+  box-shadow: 0px 4px var(--darkest-dark);
+}
+
+.fc .fc-button-group button.fc-button.fc-button-primary:last-of-type {
+  box-shadow: 4px 4px var(--darkest-dark);
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@300;600&family=Dongle:wght@300;400&family=Jost:wght@300;400;600;700&family=Kanit:wght@200;300&family=M+PLUS+Rounded+1c:wght@400;500;700;800&family=Merriweather+Sans:wght@500;700;800&family=Quicksand:wght@400;500;600&family=Secular+One&display=swap" rel="stylesheet"> 
   </head>
-  <body>
+  <body class="<%= params[:controller] %>">
   <div id="alert-wrapper">
     <%= render("layouts/alert_box", type: "notice", body: notice) if !notice.nil? %>
     <%= render("layouts/alert_box", type: "alert", body: alert) if !alert.nil? %>

--- a/spec/features/calendar_feature_spec.rb
+++ b/spec/features/calendar_feature_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'the calendar view', type: :feature, js: true do
     next_day = page.find('.fc-day-future', match: :first).native
     page.driver.browser.action.click_and_hold(task_box.native).move_to(next_day).perform
     page.driver.browser.action.release.perform
-    sleep(20)
+    sleep(30)
     expect(page.find('.fc-day-future', match: :first)).to have_content(task)
     if !db_task_start.nil?
       expect(Task.find_by(title: task).start.to_date.to_formatted_s(:db)).to eq(db_task_start.to_date.tomorrow.to_formatted_s(:db))

--- a/spec/features/calendar_feature_spec.rb
+++ b/spec/features/calendar_feature_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'the calendar view', type: :feature, js: true do
     next_day = page.find('.fc-day-future', match: :first).native
     page.driver.browser.action.click_and_hold(task_box.native).move_to(next_day).perform
     page.driver.browser.action.release.perform
-    sleep(10)
+    sleep(20)
     expect(page.find('.fc-day-future', match: :first)).to have_content(task)
     if !db_task_start.nil?
       expect(Task.find_by(title: task).start.to_date.to_formatted_s(:db)).to eq(db_task_start.to_date.tomorrow.to_formatted_s(:db))

--- a/spec/features/index_feature_spec.rb
+++ b/spec/features/index_feature_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe 'index page', type: :feature, js: true do
   describe 'for a logged out user' do
     it 'should redirect users to index after sign in' do
       visit root_path 
-      # TODO this will need to be removed after we fix the issue with tasks not being loaded in
-      sleep(2)
-      dialog = page.driver.browser.switch_to.alert
-      dialog.accept
-      # ---
       expect(current_path).to eq(new_user_session_path)  
       email = 'beepbeep@beep.com'
       pass = 'beepbeep'


### PR DESCRIPTION
I followed [this guide](https://railsapps.github.io/rails-javascript-include-external.html) to make sure that the calendar script only runs when the tasks view is rendered. 
- Changed the structure of the JS folder to organize our scripts into site-wide scripts that are individually specified in application.js. 
- Moved code from application.js so that it can serve only as our manifest file
- Added if statement to make sure that body has "tasks" class before calendar script is executed.

An alternative is using the [Paloma](https://github.com/gnclmorais/paloma) gem which allows for easy page-specific script specification but since we only have one for now and it's not hard to do this will work for the time being. We can consider switching to Paloma if we end up having a lot of JS that only needs to be rendered on one page.
